### PR TITLE
編集画面のバリデーションを実装

### DIFF
--- a/XSampleApp/EditViewController.swift
+++ b/XSampleApp/EditViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 import RealmSwift
 
-    // MARK: - Protocols
+// MARK: - Protocols
 
 protocol EditViewControllerDelegate: AnyObject {
     /// ビューを更新する
@@ -47,6 +47,11 @@ class EditViewController: UIViewController {
     }
     
     @IBAction private func didTapPostButton(_ sender: Any) {
+        guard let userName = userNameTextField.text,
+              let tweetText = tweetTextView.text else { return }
+        if userName.isEmpty || tweetText.isEmpty || tweetText == "いまどうしてる？" {
+            showAlert(title: "項目が空です", message: "ユーザー名とツイート文を入力してください")
+        } else
         if savedUserName.isEmpty {
             saveData()
         } else {
@@ -97,7 +102,7 @@ class EditViewController: UIViewController {
             dismiss(animated: true, completion: nil)
         } catch {
             print("データの追加エラー: \(error)")
-            showAlert()
+            showAlert(title: "エラーが発生しました", message: "")
         }
     }
     
@@ -124,16 +129,14 @@ class EditViewController: UIViewController {
         } catch {
             // 更新失敗時の処理
             print("データの取得エラー: \(error)")
-            showAlert()
+            showAlert(title: "エラーが発生しました", message: "")
         }
     }
     
-    
-    
     /// アラートを表示
-    private func showAlert() {
-        let alert = UIAlertController(title: "エラーが発生しました",
-                                      message: "",
+    private func showAlert(title: String, message: String) {
+        let alert = UIAlertController(title: title,
+                                      message: message,
                                       preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default))
         self.present(alert, animated: true, completion: nil)
@@ -158,5 +161,32 @@ extension EditViewController: UITextViewDelegate {
             textView.text = placeholderText
             textView.textColor = UIColor.lightGray
         }
+    }
+    
+    /// textview文字数制限
+    func textView(_ textView: UITextView,
+                  shouldChangeTextIn range: NSRange,
+                  replacementText text: String) -> Bool {
+        let textCount = textView.text.count + (text.count - range.length)
+        return checkCharacterLimit(textCount: textCount)
+    }
+    
+    func checkCharacterLimit(textCount: Int) -> Bool {
+        // 140文字以下の場合
+        if textCount <= 140 {
+            return true
+        } else {
+            showCharacterLimitAlert()
+            return false
+        }
+    }
+    
+    /// アラートを表示
+    func showCharacterLimitAlert() {
+        let alert = UIAlertController(title: "文字数制限オーバー",
+                                      message: "ツイートは140文字以内にしてください。",
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        self.present(alert, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
## やったこと
* ツイート本文が140文字を超えたらアラートを出して入力させないようにする処理を実装
* 保存項目が足りない場合「ツイートする」をタップするとアラートが出るようにする処理を実装

## 画像

| 140字以上のアラート | ユーザー名未入力のアラート | ツイート文未入力のアラート |
| --- | --- | --- |
|<img width="240" src="https://github.com/kensuke-0n0/XSampleApp/assets/163435814/c0f5e5eb-d880-4549-b6ca-62cfceb80204">|<img width="240" src="https://github.com/kensuke-0n0/XSampleApp/assets/163435814/8cb8aff3-9c7a-487a-bc47-2657418cd4ac">|<img width="240" src="https://github.com/kensuke-0n0/XSampleApp/assets/163435814/6fcd1693-4b89-45ca-8bf1-62dccaf7bd34">|

## 動作確認
- [x] 文字数制限のアラートを表示できることを確認した
- [x] 保存項目が足りない時のアラートを表示できることを確認した